### PR TITLE
회원가입에 필요한 화면을 추가했습니다.

### DIFF
--- a/Ourry/Ourry.xcodeproj/project.pbxproj
+++ b/Ourry/Ourry.xcodeproj/project.pbxproj
@@ -22,6 +22,9 @@
 		11793E5F2B1885BF008FC22C /* BlueShadowTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11793E5E2B1885BF008FC22C /* BlueShadowTextField.swift */; };
 		11793E612B188610008FC22C /* PlaneTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11793E602B188610008FC22C /* PlaneTextField.swift */; };
 		11793E632B1DC699008FC22C /* SignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11793E622B1DC699008FC22C /* SignUpViewController.swift */; };
+		11793E662B1F3B07008FC22C /* EmailVerificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11793E652B1F3B07008FC22C /* EmailVerificationView.swift */; };
+		11793E682B205C2B008FC22C /* PasswordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11793E672B205C2B008FC22C /* PasswordView.swift */; };
+		11793E6A2B206D21008FC22C /* AdditionalInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11793E692B206D21008FC22C /* AdditionalInfoView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -42,6 +45,9 @@
 		11793E5E2B1885BF008FC22C /* BlueShadowTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlueShadowTextField.swift; sourceTree = "<group>"; };
 		11793E602B188610008FC22C /* PlaneTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaneTextField.swift; sourceTree = "<group>"; };
 		11793E622B1DC699008FC22C /* SignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewController.swift; sourceTree = "<group>"; };
+		11793E652B1F3B07008FC22C /* EmailVerificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailVerificationView.swift; sourceTree = "<group>"; };
+		11793E672B205C2B008FC22C /* PasswordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordView.swift; sourceTree = "<group>"; };
+		11793E692B206D21008FC22C /* AdditionalInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdditionalInfoView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -111,7 +117,7 @@
 			children = (
 				115E26552B1618BE00FCBEE8 /* LoginViewController.swift */,
 				11793E4F2B1731A4008FC22C /* TempViewController.swift */,
-				11793E622B1DC699008FC22C /* SignUpViewController.swift */,
+				11793E642B1F1510008FC22C /* SignUp */,
 				11793E5E2B1885BF008FC22C /* BlueShadowTextField.swift */,
 				11793E602B188610008FC22C /* PlaneTextField.swift */,
 			);
@@ -132,6 +138,17 @@
 				11793E5A2B1883AB008FC22C /* LoginViewModel.swift */,
 			);
 			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		11793E642B1F1510008FC22C /* SignUp */ = {
+			isa = PBXGroup;
+			children = (
+				11793E622B1DC699008FC22C /* SignUpViewController.swift */,
+				11793E652B1F3B07008FC22C /* EmailVerificationView.swift */,
+				11793E672B205C2B008FC22C /* PasswordView.swift */,
+				11793E692B206D21008FC22C /* AdditionalInfoView.swift */,
+			);
+			name = SignUp;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -211,8 +228,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				115E266A2B161BFE00FCBEE8 /* Color+Extention.swift in Sources */,
+				11793E682B205C2B008FC22C /* PasswordView.swift in Sources */,
 				115E26562B1618BE00FCBEE8 /* LoginViewController.swift in Sources */,
+				11793E662B1F3B07008FC22C /* EmailVerificationView.swift in Sources */,
 				11793E502B1731A4008FC22C /* TempViewController.swift in Sources */,
+				11793E6A2B206D21008FC22C /* AdditionalInfoView.swift in Sources */,
 				11793E5D2B188459008FC22C /* UIViewController+Extention.swift in Sources */,
 				11793E582B188370008FC22C /* AuthService.swift in Sources */,
 				115E26522B1618BE00FCBEE8 /* AppDelegate.swift in Sources */,

--- a/Ourry/Ourry/Resources/Color+Extention.swift
+++ b/Ourry/Ourry/Resources/Color+Extention.swift
@@ -14,6 +14,7 @@ extension UIColor {
     static let blueShadowColor              = UIColor(hexCode: "C1D0FF")
     static let brandLogoColor               = UIColor(hexCode: "4667D1")
     static let buttonColor                  = UIColor(hexCode: "58B1F2")
+    static let loginNextButtonColor         = UIColor(hexCode: "1780CD")
     static let surveyOptionBackroundColor   = UIColor(hexCode: "E5EFFE")
     static let voteResultColor              = UIColor(hexCode: "9AC8FF")
     

--- a/Ourry/Ourry/Views/AdditionalInfoView.swift
+++ b/Ourry/Ourry/Views/AdditionalInfoView.swift
@@ -1,0 +1,142 @@
+//
+//  AdditionalInfoView.swift
+//  Ourry
+//
+//  Created by SeongHoon Jang on 2023/12/06.
+//
+
+import UIKit
+import SnapKit
+
+class AdditionalInfoView: UIView {
+
+    //MARK: - UI
+    private let nicknameTitle: UILabel = {
+        let label = UILabel()
+        label.text = "닉네임"
+        label.textColor = .black
+        label.font = .preferredFont(forTextStyle: .headline)
+        return label
+    }()
+    
+    private let phoneNumberTitle: UILabel = {
+        let label = UILabel()
+        label.text = "휴대폰번호"
+        label.textColor = .black
+        label.font = .preferredFont(forTextStyle: .headline)
+        return label
+    }()
+    
+    private lazy var nicknameTextField: PlaneTextField = {
+        let textField = PlaneTextField(placeholder: "닉네임을 입력해주세요.")
+        textField.addTarget(self, action: #selector(nicknameTextFieldDidChange), for: .editingChanged)
+        return textField
+    }()
+    
+    private lazy var phoneNumberTextField: PlaneTextField = {
+        let textField = PlaneTextField(placeholder: "휴대폰 번호를 입력해주세요.")
+        textField.addTarget(self, action: #selector(phoneNumberTextFieldDidChange), for: .editingChanged)
+        return textField
+    }()
+    
+    private lazy var nicknameErrorLabel: UILabel = {
+        let label = UILabel()
+        label.sizeToFit()
+        label.text = "닉네임에는 특수문자가 포함될 수 없습니다. 다시 확인해주세요."
+        label.numberOfLines = 0
+        label.font = UIFont.preferredFont(forTextStyle: .footnote)
+        label.textColor = .clear
+        return label
+    }()
+    
+    private lazy var phoneNumberErrorLabel: UILabel = {
+        let label = UILabel()
+        label.sizeToFit()
+        label.numberOfLines = 0
+        label.text = "올바른 휴대폰 번호를 입력해주세요."
+        label.font = UIFont.preferredFont(forTextStyle: .footnote)
+        label.textColor = .clear
+        return label
+    }()
+    
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupUI()
+    }
+    
+    
+    //MARK: - Functions
+    private func setupUI() {
+        addSubview(nicknameTitle)
+        addSubview(nicknameTextField)
+        addSubview(phoneNumberTextField)
+        
+        addSubview(phoneNumberTitle)
+        addSubview(nicknameErrorLabel)
+        addSubview(phoneNumberErrorLabel)
+        
+        nicknameTitle.snp.makeConstraints { make in
+            make.top.equalTo(self.snp.top)
+            make.leading.trailing.equalTo(self)
+        }
+        
+        nicknameTextField.snp.makeConstraints { make in
+            make.top.equalTo(nicknameTitle.snp.bottom).offset(6)
+            make.leading.trailing.equalTo(self)
+        }
+        
+        nicknameErrorLabel.snp.makeConstraints { make in
+            make.top.equalTo(nicknameTextField.snp.bottom).offset(6)
+            make.leading.trailing.equalTo(self)
+        }
+        
+        phoneNumberTitle.snp.makeConstraints{ make in
+            make.top.equalTo(nicknameTextField.snp.bottom).offset(48)
+            make.leading.trailing.equalTo(self)
+        }
+        
+        phoneNumberTextField.snp.makeConstraints { make in
+            make.top.equalTo(phoneNumberTitle.snp.bottom).offset(6)
+            make.leading.trailing.equalTo(self)
+        }
+        
+        phoneNumberErrorLabel.snp.makeConstraints { make in
+            make.top.equalTo(phoneNumberTextField.snp.bottom).offset(6)
+            make.leading.trailing.equalTo(self)
+        }
+    }
+    
+    // 닉네임 유효성 검사
+    func isValidNickname(nickname: String) -> Bool {
+        return !nickname.contains("!")
+    }
+    
+    // 휴대폰번호 유효성 검사
+    func isValidPhoneNumber(number: String) -> Bool {
+        return number.count >= 9
+    }
+    
+    @objc private func nicknameTextFieldDidChange() {
+        if !isValidNickname(nickname: nicknameTextField.text ?? "") {
+            nicknameErrorLabel.textColor = .red
+        } else {
+            nicknameErrorLabel.textColor = .clear
+        }
+        
+    }
+
+    @objc private func phoneNumberTextFieldDidChange() {
+        if !isValidPhoneNumber(number: phoneNumberTextField.text ?? "") {
+            phoneNumberErrorLabel.textColor = .red
+        } else {
+            phoneNumberErrorLabel.textColor = .clear
+        }
+    }
+    
+}

--- a/Ourry/Ourry/Views/EmailVerificationView.swift
+++ b/Ourry/Ourry/Views/EmailVerificationView.swift
@@ -1,0 +1,120 @@
+//
+//  EmailVerificationView.swift
+//  Ourry
+//
+//  Created by SeongHoon Jang on 2023/12/05.
+//
+
+import UIKit
+import SnapKit
+
+class EmailVerificationView: UIView, UITextFieldDelegate {
+    
+    //MARK: - UI
+    private let emailLabel: UILabel = {
+        let label = UILabel()
+        label.text = "이메일"
+        label.textColor = .black
+        label.font = .preferredFont(forTextStyle: .headline)
+        return label
+    }()
+    
+    private lazy var emailTextField: PlaneTextField = {
+        let textField = PlaneTextField(placeholder: "이메일을 입력하세요")
+        return textField
+    }()
+    
+    private lazy var emailVerificationCodeTextField: PlaneTextField = {
+        let textField = PlaneTextField(placeholder: "인증번호를 입력하세요")
+        return textField
+    }()
+
+    private lazy var verificationRequestButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("인증번호 발송", for: .normal)
+        button.setTitleColor(.white, for: .normal)
+        button.addTarget(self, action: #selector(request), for: .touchUpInside)
+        button.backgroundColor = .buttonColor
+        button.titleLabel?.font = UIFont.boldSystemFont(ofSize: 12)
+        button.layer.cornerRadius = 8
+        return button
+    }()
+
+    private lazy var verificationCheckButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("인증번호 확인", for: .normal)
+        button.setTitleColor(.white, for: .normal)
+        button.addTarget(self, action: #selector(check), for: .touchUpInside)
+        button.backgroundColor = .buttonColor
+        button.titleLabel?.font = UIFont.boldSystemFont(ofSize: 12)
+        button.layer.cornerRadius = 8
+        return button
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupUI()
+    }
+    
+    
+    //MARK: - Functions
+    private func setupUI() {
+        addSubview(emailLabel)
+        addSubview(emailTextField)
+        addSubview(verificationRequestButton)
+        addSubview(emailVerificationCodeTextField)
+        addSubview(verificationCheckButton)
+        
+        emailLabel.snp.makeConstraints { make in
+            make.top.equalTo(self.snp.top)
+            make.leading.equalTo(self)
+        }
+        
+        emailTextField.snp.makeConstraints { make in
+            make.top.equalTo(emailLabel.snp.bottom).offset(6)
+            make.leading.equalTo(self)
+            make.trailing.equalTo(verificationRequestButton.snp.leading).offset(-4)
+            make.height.equalTo(36)
+        }
+
+        verificationRequestButton.snp.makeConstraints { make in
+            make.top.equalTo(emailTextField)
+            make.trailing.equalTo(self)
+            make.width.equalTo(80)
+            make.height.equalTo(36)
+        }
+
+        emailVerificationCodeTextField.snp.makeConstraints { make in
+            make.top.equalTo(emailTextField.snp.bottom).offset(6)
+            make.leading.equalTo(emailTextField.snp.leading)
+            make.trailing.equalTo(emailTextField.snp.trailing)
+            make.height.equalTo(36)
+        }
+
+        verificationCheckButton.snp.makeConstraints { make in
+            make.top.equalTo(emailTextField.snp.bottom).offset(6)
+            make.trailing.equalTo(verificationRequestButton.snp.trailing)
+            make.width.equalTo(80)
+            make.height.equalTo(36)
+        }
+    }
+    
+    func getEmailValue() -> String {
+        return emailTextField.text ?? ""
+    }
+    
+    //TODO: 이메일 인증코드 요청
+    @objc private func request() {
+        print(emailTextField.text ?? "Empty")
+    }
+    
+    //TODO: 이메일 인증코드 확인
+    @objc private func check() {
+        print(emailVerificationCodeTextField.text ?? "Empty")
+    }
+}

--- a/Ourry/Ourry/Views/LoginViewController.swift
+++ b/Ourry/Ourry/Views/LoginViewController.swift
@@ -31,17 +31,17 @@ class LoginViewController: UIViewController {
     
     private lazy var emailErrorLabel: UILabel = {
         let label = UILabel()
-        label.text = "Email Error"
+        label.text = "이메일을 확인해주세요."
         label.font = UIFont.preferredFont(forTextStyle: .footnote)
-        label.textColor = .red
+        label.textColor = .clear
         return label
     }()
     
     private lazy var passwordErrorLabel: UILabel = {
         let label = UILabel()
-        label.text = "Password Error"
+        label.text = "비밀번호를 확인해주세요."
         label.font = UIFont.preferredFont(forTextStyle: .footnote)
-        label.textColor = .red
+        label.textColor = .clear
         return label
     }()
     
@@ -186,15 +186,15 @@ class LoginViewController: UIViewController {
     @objc func loginButtonTapped() {
                 
         if !isValidEmail(email: emailTextField.text ?? "") {
-            emailErrorLabel.text = "이메일을 확인해주세요."
-            return
+            emailErrorLabel.textColor = .red
         } else {
-            emailErrorLabel.text = ""
+            emailErrorLabel.textColor = .clear
         }
         
         if passwordTextField.text?.count ?? 0 < 5 {
-            passwordErrorLabel.text = "비밀번호를 확인해주세요."
-            return
+            passwordErrorLabel.textColor = .red
+        } else {
+            passwordErrorLabel.textColor = .clear
         }
         
         //TODO: 로그인 로직

--- a/Ourry/Ourry/Views/PasswordView.swift
+++ b/Ourry/Ourry/Views/PasswordView.swift
@@ -1,0 +1,144 @@
+//
+//  PasswordView.swift
+//  Ourry
+//
+//  Created by SeongHoon Jang on 2023/12/06.
+//
+
+import UIKit
+import SnapKit
+
+class PasswordView: UIView {
+    
+    //MARK: - UI
+    private let passwordTitle: UILabel = {
+        let label = UILabel()
+        label.text = "비밀번호"
+        label.textColor = .black
+        label.font = .preferredFont(forTextStyle: .headline)
+        return label
+    }()
+    
+    private let passwordCheckTitle: UILabel = {
+        let label = UILabel()
+        label.text = "비밀번호 확인"
+        label.textColor = .black
+        label.font = .preferredFont(forTextStyle: .headline)
+        return label
+    }()
+    
+    private lazy var passwordTextField: PlaneTextField = {
+        let textField = PlaneTextField(placeholder: "비밀번호를 입력해주세요.")
+        textField.addTarget(self, action: #selector(passwordTextFieldDidChange), for: .editingChanged)
+        return textField
+    }()
+    
+    private lazy var confirmPasswordTextField: PlaneTextField = {
+        let textField = PlaneTextField(placeholder: "인증번호를 입력하세요.")
+        textField.addTarget(self, action: #selector(passwordConfirmTextFieldDidChange), for: .editingChanged)
+        return textField
+    }()
+    
+    private lazy var passwordErrorLabel: UILabel = {
+        let label = UILabel()
+        label.sizeToFit()
+        label.text = "비밀번호는 대소문자를 포함해서 12자리에서 16자리를 입력해야 합니다."
+        label.numberOfLines = 0
+        label.font = UIFont.preferredFont(forTextStyle: .footnote)
+        label.textColor = .clear
+        return label
+    }()
+    
+    private lazy var confirmPasswordErrorLabel: UILabel = {
+        let label = UILabel()
+        label.sizeToFit()
+        label.numberOfLines = 0
+        label.text = "입력한 비밀번호와 일치하지 않습니다. 다시 확인해주세요."
+        label.font = UIFont.preferredFont(forTextStyle: .footnote)
+        label.textColor = .clear
+        return label
+    }()
+    
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupUI()
+    }
+    
+    
+    //MARK: - Functions
+    private func setupUI() {
+        addSubview(passwordTitle)
+        addSubview(passwordTextField)
+        addSubview(confirmPasswordTextField)
+        
+        addSubview(passwordCheckTitle)
+        addSubview(passwordErrorLabel)
+        addSubview(confirmPasswordErrorLabel)
+        
+        passwordTitle.snp.makeConstraints { make in
+            make.top.equalTo(self.snp.top)
+            make.leading.trailing.equalTo(self)
+        }
+        
+        passwordTextField.snp.makeConstraints { make in
+            make.top.equalTo(passwordTitle.snp.bottom).offset(6)
+            make.leading.trailing.equalTo(self)
+        }
+        
+        passwordErrorLabel.snp.makeConstraints { make in
+            make.top.equalTo(passwordTextField.snp.bottom).offset(6)
+            make.leading.trailing.equalTo(self)
+        }
+        
+        passwordCheckTitle.snp.makeConstraints{ make in
+            make.top.equalTo(passwordTextField.snp.bottom).offset(48)
+            make.leading.trailing.equalTo(self)
+        }
+        
+        confirmPasswordTextField.snp.makeConstraints { make in
+            make.top.equalTo(passwordCheckTitle.snp.bottom).offset(6)
+            make.leading.trailing.equalTo(self)
+        }
+        
+        confirmPasswordErrorLabel.snp.makeConstraints { make in
+            make.top.equalTo(confirmPasswordTextField.snp.bottom).offset(6)
+            make.leading.trailing.equalTo(self)
+        }
+    }
+    
+    // 유효한 비밀번호인지 검사
+    func isValidPassword(pw: String?) -> Bool {
+        let password = pw ?? ""
+        return (password.count >= 8) && (password.count <= 16)
+    }
+    
+    @objc private func passwordTextFieldDidChange() {
+        if !isValidPassword(pw: passwordTextField.text) {
+            passwordErrorLabel.textColor = .red
+        } else {
+            passwordErrorLabel.textColor = .clear
+        }
+        
+    }
+    
+    // 동일한 비밀번호를 입력했는지 검사
+    func isSamePassword(pw1: String?, pw2: String?) -> Bool {
+        return (pw1 ?? "") == (pw2 ?? "")
+    }
+    
+    @objc private func passwordConfirmTextFieldDidChange() {
+        if !isSamePassword(pw1: passwordTextField.text,
+                           pw2: confirmPasswordTextField.text) {
+            confirmPasswordErrorLabel.textColor = .red
+        } else {
+            confirmPasswordErrorLabel.textColor = .clear
+        }
+    }
+    
+}

--- a/Ourry/Ourry/Views/SignUpViewController.swift
+++ b/Ourry/Ourry/Views/SignUpViewController.swift
@@ -9,24 +9,148 @@ import UIKit
 import SnapKit
 
 class SignUpViewController: UIViewController {
+
+    //MARK: - UI
+    lazy var nextButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("다음화면으로 이동", for: .normal)
+        button.setTitleColor(.loginNextButtonColor, for: .normal)
+        button.addTarget(self, action: #selector(nextAction), for: .touchUpInside)
+        button.backgroundColor = .white
+        button.layer.cornerRadius = 8
+        button.layer.borderWidth = 2
+        button.layer.borderColor = UIColor.loginNextButtonColor.cgColor
+        button.titleLabel?.font = UIFont.boldSystemFont(ofSize: 16)
+        button.tintColor = UIColor.loginNextButtonColor
+        return button
+    }()
+    
+    lazy var backButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("뒤로가기", for: .normal)
+        button.setTitleColor(.black, for: .normal)
+        button.addTarget(self, action: #selector(backAction), for: .touchUpInside)
+        button.backgroundColor = .white
+        button.layer.cornerRadius = 8
+        button.layer.borderWidth = 2
+        button.layer.borderColor = UIColor.clear.cgColor
+        button.titleLabel?.font = UIFont.boldSystemFont(ofSize: 16)
+        button.tintColor = .black
+        return button
+    }()
+        
+    let emailInputView = EmailVerificationView()
+    let passwordView = PasswordView()
+    let additionalInfoView = AdditionalInfoView()
+    
+    // 보여줄 화면을 지정하기 위한 변수
+    private var views: [UIView] = []
+    private var currentIndex: Int = 0
     
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .backgroundColor
         
-        let myFirstView = UIButton()
-        myFirstView.setTitle("확인", for: .normal)
-//        myFirstView.addTarget(self, action: nil, for: .touchUpInside)
-        myFirstView.translatesAutoresizingMaskIntoConstraints = false
-        myFirstView.backgroundColor = .green
-        self.view.addSubview(myFirstView)
-
-        myFirstView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor).isActive = true
-        myFirstView.centerYAnchor.constraint(equalTo: self.view.centerYAnchor, constant: 0).isActive = true
-
-        myFirstView.widthAnchor.constraint(equalToConstant: 100).isActive = true
-        myFirstView.heightAnchor.constraint(equalToConstant: 150).isActive = true
-        myFirstView.layer.cornerRadius = 30
+        // 상단 사용자 입력 영역
+        createView(newView: emailInputView)
+        createView(newView: passwordView)
+        createView(newView: additionalInfoView)
+        
+        showView(at: currentIndex)
+        createButtons()
+        changeButton(at: currentIndex)
+        // 하단 버튼 영역
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+      navigationController?.setNavigationBarHidden(true, animated: true) // 뷰 컨트롤러가 나타날 때 숨기기
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+      navigationController?.setNavigationBarHidden(false, animated: true) // 뷰 컨트롤러가 사라질 때 나타내기
+    }
+    
+    
+    //MARK: - Functions
+    /// 회원가입 화면을 빠져나올 때 사용
+    func popToLoginViewController() {
+        self.navigationController?.popViewController(animated: true)
+    }
+    
+    /// 뒤로가기/다음화면에 대한 버튼을 생성
+    func createButtons() {
+        view.addSubview(nextButton)
+        view.addSubview(backButton)
+        
+        nextButton.snp.makeConstraints { make in
+            make.top.equalTo(view.frame.height * 0.8)
+            make.leading.trailing.equalToSuperview().inset(16)
+            make.height.equalTo(40)
+        }
+        
+        backButton.snp.makeConstraints { make in
+            make.top.equalTo(nextButton.snp.bottom).offset(8)
+            make.leading.trailing.equalToSuperview().inset(16)
+        }
+    }
+    
+    // 로그인에 필요한 화면들을 생성
+    func createView(newView: UIView) {
+        view.addSubview(newView)
+        
+        newView.snp.makeConstraints { make in
+            make.top.equalTo(view.frame.height * 0.2)
+            make.height.equalTo(view.frame.height * 0.6)
+            make.leading.trailing.equalToSuperview().inset(16)
+        }
+        
+        newView.isHidden = true
+        views.append(newView)
+    }
+    
+    // 해당 index의 view만 활성화
+    func showView(at index: Int) {
+        for i in 0..<views.count {
+            views[i].isHidden = (i != index)
+        }
+    }
+    
+    // 특정 index에 해당되는 경우 버튼의 텍스트를 변경
+    func changeButton(at index: Int) {
+        if index == 0 {
+            backButton.setTitle("회원가입 취소", for: .normal)
+        } else {
+            backButton.setTitle("뒤로가기", for: .normal)
+        }
+    
+        if index == views.count-1 {
+            nextButton.setTitle("회원가입 완료", for: .normal)
+        } else {
+            nextButton.setTitle("다음화면으로 이동", for: .normal)
+        }
+    }
+
+    @objc func nextAction() {
+        currentIndex += 1
+        if currentIndex >= views.count {
+            print("회원가입 완료")
+            popToLoginViewController()
+        } else {
+            
+            showView(at: currentIndex)
+            changeButton(at: currentIndex)
+        }
+    }
+
+    @objc func backAction() {
+        currentIndex -= 1
+        if currentIndex < 0 {
+            print("회원가입 취소")
+            popToLoginViewController()
+        } else {
+            showView(at: currentIndex)
+            changeButton(at: currentIndex)
+        }
+    }
+
 }


### PR DESCRIPTION
# 배경
회원가입에 필요한 화면과 간단한 로직에 대해 구현했습니다.

# 작업내용
- d09001cfb7c5257766cfb173033b607a9f718d37
  - 컬러셋에 새로운 컬러를 추가했습니다.

- 8f254fad3834dc68780bc21d0f16883c0a6ccd37
  - 회원가입 화면을 추가했습니다.
  - 회원가입에 필요한 3가지 uiView를 추가했습니다.(이메일인증, 화면 비밀번호입력 화면, 추가정보입력 화면)

# 해야 할 일
- 각각의 텍스트필드별 검증 로직 구현
  - 백앤드 API가 구현이 되어있지 않아 아직 구현하지 않았습니다.

- 앞으로 추가해야하는 앱단 검증 로직입니다.
  - 이메일 형식
  - 비밀번호 형식
  - 닉네임(특수문자 제외) 형식
  - 휴대폰번호 형식

-  텍스트필드 관련
   - 공통적으로 비활성화가 필요한 부분: 첫글자 대문자, 오타수정
   - 비밀번호 입력란은 **** 처리를 해야합니다.
   - 휴대폰번호 입력란은 숫자만 입력이 가능하게 해야합니다.

# 스크린샷
### 회원가입 과정
<img src = "https://github.com/Ourry/Ourry-iOS/assets/57349859/dee1ad16-02b5-4577-8dca-67146387ca26" width="30%" height="30%">
