### PR TITLE
비밀번호 재설정에 필요한 화면을 추가했습니다.

### DIFF
--- a/Ourry/Ourry.xcodeproj/project.pbxproj
+++ b/Ourry/Ourry.xcodeproj/project.pbxproj
@@ -25,6 +25,10 @@
 		11793E662B1F3B07008FC22C /* EmailVerificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11793E652B1F3B07008FC22C /* EmailVerificationView.swift */; };
 		11793E682B205C2B008FC22C /* PasswordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11793E672B205C2B008FC22C /* PasswordView.swift */; };
 		11793E6A2B206D21008FC22C /* AdditionalInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11793E692B206D21008FC22C /* AdditionalInfoView.swift */; };
+		11793E742B22F160008FC22C /* LoginNextButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11793E732B22F160008FC22C /* LoginNextButton.swift */; };
+		11793E762B24AF80008FC22C /* ResetEmailVerifyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11793E752B24AF80008FC22C /* ResetEmailVerifyViewController.swift */; };
+		11793E782B24B47B008FC22C /* LoginBackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11793E772B24B47B008FC22C /* LoginBackButton.swift */; };
+		11793E7C2B25A40D008FC22C /* ResetPasswordInputViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11793E7B2B25A40D008FC22C /* ResetPasswordInputViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -48,6 +52,10 @@
 		11793E652B1F3B07008FC22C /* EmailVerificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailVerificationView.swift; sourceTree = "<group>"; };
 		11793E672B205C2B008FC22C /* PasswordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordView.swift; sourceTree = "<group>"; };
 		11793E692B206D21008FC22C /* AdditionalInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdditionalInfoView.swift; sourceTree = "<group>"; };
+		11793E732B22F160008FC22C /* LoginNextButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginNextButton.swift; sourceTree = "<group>"; };
+		11793E752B24AF80008FC22C /* ResetEmailVerifyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetEmailVerifyViewController.swift; sourceTree = "<group>"; };
+		11793E772B24B47B008FC22C /* LoginBackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginBackButton.swift; sourceTree = "<group>"; };
+		11793E7B2B25A40D008FC22C /* ResetPasswordInputViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetPasswordInputViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -115,11 +123,9 @@
 		11793E522B1882FC008FC22C /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				115E26552B1618BE00FCBEE8 /* LoginViewController.swift */,
+				11793E702B22EBE3008FC22C /* Components */,
+				11793E6D2B22EB42008FC22C /* Users */,
 				11793E4F2B1731A4008FC22C /* TempViewController.swift */,
-				11793E642B1F1510008FC22C /* SignUp */,
-				11793E5E2B1885BF008FC22C /* BlueShadowTextField.swift */,
-				11793E602B188610008FC22C /* PlaneTextField.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -149,6 +155,44 @@
 				11793E692B206D21008FC22C /* AdditionalInfoView.swift */,
 			);
 			name = SignUp;
+			sourceTree = "<group>";
+		};
+		11793E6D2B22EB42008FC22C /* Users */ = {
+			isa = PBXGroup;
+			children = (
+				11793E6E2B22EBA8008FC22C /* Login */,
+				11793E642B1F1510008FC22C /* SignUp */,
+				11793E6F2B22EBB1008FC22C /* ResetPassword */,
+			);
+			name = Users;
+			sourceTree = "<group>";
+		};
+		11793E6E2B22EBA8008FC22C /* Login */ = {
+			isa = PBXGroup;
+			children = (
+				115E26552B1618BE00FCBEE8 /* LoginViewController.swift */,
+			);
+			name = Login;
+			sourceTree = "<group>";
+		};
+		11793E6F2B22EBB1008FC22C /* ResetPassword */ = {
+			isa = PBXGroup;
+			children = (
+				11793E752B24AF80008FC22C /* ResetEmailVerifyViewController.swift */,
+				11793E7B2B25A40D008FC22C /* ResetPasswordInputViewController.swift */,
+			);
+			name = ResetPassword;
+			sourceTree = "<group>";
+		};
+		11793E702B22EBE3008FC22C /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				11793E5E2B1885BF008FC22C /* BlueShadowTextField.swift */,
+				11793E602B188610008FC22C /* PlaneTextField.swift */,
+				11793E732B22F160008FC22C /* LoginNextButton.swift */,
+				11793E772B24B47B008FC22C /* LoginBackButton.swift */,
+			);
+			name = Components;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -228,8 +272,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				115E266A2B161BFE00FCBEE8 /* Color+Extention.swift in Sources */,
+				11793E742B22F160008FC22C /* LoginNextButton.swift in Sources */,
 				11793E682B205C2B008FC22C /* PasswordView.swift in Sources */,
+				11793E782B24B47B008FC22C /* LoginBackButton.swift in Sources */,
 				115E26562B1618BE00FCBEE8 /* LoginViewController.swift in Sources */,
+				11793E7C2B25A40D008FC22C /* ResetPasswordInputViewController.swift in Sources */,
 				11793E662B1F3B07008FC22C /* EmailVerificationView.swift in Sources */,
 				11793E502B1731A4008FC22C /* TempViewController.swift in Sources */,
 				11793E6A2B206D21008FC22C /* AdditionalInfoView.swift in Sources */,
@@ -238,6 +285,7 @@
 				115E26522B1618BE00FCBEE8 /* AppDelegate.swift in Sources */,
 				11793E632B1DC699008FC22C /* SignUpViewController.swift in Sources */,
 				11793E612B188610008FC22C /* PlaneTextField.swift in Sources */,
+				11793E762B24AF80008FC22C /* ResetEmailVerifyViewController.swift in Sources */,
 				11793E552B188321008FC22C /* User.swift in Sources */,
 				11793E5F2B1885BF008FC22C /* BlueShadowTextField.swift in Sources */,
 				115E26542B1618BE00FCBEE8 /* SceneDelegate.swift in Sources */,

--- a/Ourry/Ourry/ViewModels/LoginViewModel.swift
+++ b/Ourry/Ourry/ViewModels/LoginViewModel.swift
@@ -21,11 +21,6 @@ class LoginViewModel {
         }
     }
     
-//    var users: [User] = [
-//        User(email: "abc1234@naver.com", password: "qwerty1234"),
-//        User(email: "dazzlynnnn@gmail.com", password: "asdfasdf5678")
-//    ]
-    
     // 아이디 형식 검사
     func isValidEmail(id: String) -> Bool {
         let emailRegEx = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"

--- a/Ourry/Ourry/Views/AdditionalInfoView.swift
+++ b/Ourry/Ourry/Views/AdditionalInfoView.swift
@@ -73,14 +73,10 @@ class AdditionalInfoView: UIView {
     
     //MARK: - Functions
     private func setupUI() {
+        // 닉네임 입력
         addSubview(nicknameTitle)
         addSubview(nicknameTextField)
-        addSubview(phoneNumberTextField)
-        
-        addSubview(phoneNumberTitle)
         addSubview(nicknameErrorLabel)
-        addSubview(phoneNumberErrorLabel)
-        
         nicknameTitle.snp.makeConstraints { make in
             make.top.equalTo(self.snp.top)
             make.leading.trailing.equalTo(self)
@@ -96,6 +92,10 @@ class AdditionalInfoView: UIView {
             make.leading.trailing.equalTo(self)
         }
         
+        // 휴대폰번호 입력
+        addSubview(phoneNumberTitle)
+        addSubview(phoneNumberTextField)
+        addSubview(phoneNumberErrorLabel)
         phoneNumberTitle.snp.makeConstraints{ make in
             make.top.equalTo(nicknameTextField.snp.bottom).offset(48)
             make.leading.trailing.equalTo(self)

--- a/Ourry/Ourry/Views/BlueShadowTextField.swift
+++ b/Ourry/Ourry/Views/BlueShadowTextField.swift
@@ -14,6 +14,7 @@ class BlueShadowTextField: UITextField {
         
         self.placeholder = placeholder
         self.borderStyle = .roundedRect
+        self.autocapitalizationType = .none
         self.layer.masksToBounds = false
         self.layer.shadowColor = UIColor.blueShadowColor.cgColor
         self.layer.shadowOffset = CGSize(width: 0, height: 1)

--- a/Ourry/Ourry/Views/EmailVerificationView.swift
+++ b/Ourry/Ourry/Views/EmailVerificationView.swift
@@ -21,11 +21,13 @@ class EmailVerificationView: UIView, UITextFieldDelegate {
     
     private lazy var emailTextField: PlaneTextField = {
         let textField = PlaneTextField(placeholder: "이메일을 입력하세요")
+        textField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
         return textField
     }()
     
     private lazy var emailVerificationCodeTextField: PlaneTextField = {
         let textField = PlaneTextField(placeholder: "인증번호를 입력하세요")
+        textField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
         return textField
     }()
 
@@ -50,6 +52,8 @@ class EmailVerificationView: UIView, UITextFieldDelegate {
         button.layer.cornerRadius = 8
         return button
     }()
+    
+    var isVerified: Bool = false
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -102,6 +106,11 @@ class EmailVerificationView: UIView, UITextFieldDelegate {
             make.width.equalTo(80)
             make.height.equalTo(36)
         }
+    }
+    
+    @objc func textFieldDidChange() {
+        self.isVerified = (self.emailTextField.text?.count ?? 0 > 0) && (self.emailVerificationCodeTextField.text?.count ?? 0 > 0)
+        print(isVerified)
     }
     
     func getEmailValue() -> String {

--- a/Ourry/Ourry/Views/LoginBackButton.swift
+++ b/Ourry/Ourry/Views/LoginBackButton.swift
@@ -1,0 +1,30 @@
+//
+//  LoginBackButton.swift
+//  Ourry
+//
+//  Created by SeongHoon Jang on 2023/12/09.
+//
+
+import UIKit
+
+//MARK: - 로그인 Back 버튼
+class LoginBackButton: UIButton {
+
+    init() {
+        super.init(frame: .zero)
+        setupUI()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupUI() {
+        titleLabel?.font = UIFont.boldSystemFont(ofSize: 16)
+        layer.cornerRadius = 8
+        layer.borderWidth = 2
+        setTitleColor(.black, for: .normal)
+        layer.borderColor = UIColor.clear.cgColor
+        backgroundColor = .white
+    }
+}

--- a/Ourry/Ourry/Views/LoginNextButton.swift
+++ b/Ourry/Ourry/Views/LoginNextButton.swift
@@ -1,0 +1,48 @@
+//
+//  CustomNextButton.swift
+//  Ourry
+//
+//  Created by SeongHoon Jang on 2023/12/08.
+//
+
+import UIKit
+
+////MARK: - 로그인 Next 버튼
+class LoginNextButton: UIButton {
+    
+    var isEnable: Bool = false {
+        didSet {
+            updateButtonState()
+        }
+    }
+
+    init() {
+        super.init(frame: .zero)
+        setupUI()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // 버튼 UI 설정
+    private func setupUI() {
+        backgroundColor = .white
+        titleLabel?.font = UIFont.boldSystemFont(ofSize: 16)
+        setTitleColor(.loginNextButtonColor, for: .normal)
+        layer.cornerRadius = 8
+        layer.borderWidth = 2
+        layer.borderColor = UIColor.loginNextButtonColor.cgColor
+        
+        updateButtonState()
+    }
+    
+    // 버튼의 활성화 여부에 따라 색상/활성화여부 설정
+    private func updateButtonState() {
+        let color: UIColor = isEnable ? .loginNextButtonColor : .disabledButtonColor
+        setTitleColor(color, for: .normal)
+        layer.borderColor = color.cgColor
+        isEnabled = isEnable
+    }
+
+}

--- a/Ourry/Ourry/Views/LoginViewController.swift
+++ b/Ourry/Ourry/Views/LoginViewController.swift
@@ -209,8 +209,8 @@ class LoginViewController: UIViewController {
 
     // 비밀번호 재설정 로직
     @objc func forgotPasswordButtonTapped() {
-        // Implement forgot password navigation logic here
-        print("forgotPasswordButtonTapped")
+        let emailVerificationViewController = ResetEmailVerifyViewController()
+        navigationController?.pushViewController(emailVerificationViewController, animated:true)
     }
     
     // 이메일 유효성 검사

--- a/Ourry/Ourry/Views/PasswordView.swift
+++ b/Ourry/Ourry/Views/PasswordView.swift
@@ -73,14 +73,10 @@ class PasswordView: UIView {
     
     //MARK: - Functions
     private func setupUI() {
+        // 비밀번호 입력
         addSubview(passwordTitle)
         addSubview(passwordTextField)
-        addSubview(confirmPasswordTextField)
-        
-        addSubview(passwordCheckTitle)
         addSubview(passwordErrorLabel)
-        addSubview(confirmPasswordErrorLabel)
-        
         passwordTitle.snp.makeConstraints { make in
             make.top.equalTo(self.snp.top)
             make.leading.trailing.equalTo(self)
@@ -95,7 +91,11 @@ class PasswordView: UIView {
             make.top.equalTo(passwordTextField.snp.bottom).offset(6)
             make.leading.trailing.equalTo(self)
         }
-        
+
+        // 비밀번호 확인
+        addSubview(passwordCheckTitle)
+        addSubview(confirmPasswordTextField)
+        addSubview(confirmPasswordErrorLabel)
         passwordCheckTitle.snp.makeConstraints{ make in
             make.top.equalTo(passwordTextField.snp.bottom).offset(48)
             make.leading.trailing.equalTo(self)

--- a/Ourry/Ourry/Views/PlaneTextField.swift
+++ b/Ourry/Ourry/Views/PlaneTextField.swift
@@ -13,7 +13,7 @@ class PlaneTextField: UITextField {
         super.init(frame: .zero)
         
         self.placeholder = placeholder
-        
+        self.autocapitalizationType = .none
         self.borderStyle = .roundedRect
     }
 

--- a/Ourry/Ourry/Views/ResetEmailVerifyViewController.swift
+++ b/Ourry/Ourry/Views/ResetEmailVerifyViewController.swift
@@ -1,0 +1,257 @@
+//
+//  ResetEmailVerifyViewController.swift
+//  Ourry
+//
+//  Created by SeongHoon Jang on 2023/12/09.
+//
+
+import UIKit
+import SnapKit
+
+class ResetEmailVerifyViewController: UIViewController {
+    
+    private let emailTitle: UILabel = {
+        let title = UILabel()
+        title.text = "이메일 인증"
+        title.textColor = .black
+        title.font = .preferredFont(forTextStyle: .headline)
+        return title
+    }()
+    
+    private lazy var emailTextField: PlaneTextField = {
+        let textField = PlaneTextField(placeholder: "이메일을 입력해주세요.")
+        textField.addTarget(self, action: #selector(emailTextFieldDidChange), for: .editingChanged)
+        return textField
+    }()
+    
+    private lazy var authInputTextField: PlaneTextField = {
+        let textField = PlaneTextField(placeholder: "인증 번호를 입력해주세요.")
+        textField.addTarget(self, action: #selector(authTextFieldDidChange), for: .editingChanged)
+        return textField
+    }()
+
+    private lazy var verificationButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("인증번호 요청", for: .normal)
+        button.isEnabled = false
+        button.backgroundColor = .gray
+        button.layer.cornerRadius = 8
+        button.setTitleColor(.white, for: .normal)
+        button.addTarget(self, action: #selector(verificationButtonTapped), for: .touchUpInside)
+        return button
+    }()
+    
+    private lazy var authConfirmButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("인증번호 확인", for: .normal)
+        button.isEnabled = false
+        button.backgroundColor = .gray
+        button.layer.cornerRadius = 8
+        button.setTitleColor(.white, for: .normal)
+        button.addTarget(self, action: #selector(authConfirmButtonTapped), for: .touchUpInside)
+        return button
+    }()
+
+    private var countdownLabel: UILabel = {
+        let label = UILabel()
+        label.text = ""
+        label.font = .preferredFont(forTextStyle: .footnote)
+        label.textColor = .red
+        label.textAlignment = .right
+        return label
+    }()
+
+    private lazy var nextButton: LoginNextButton = {
+        let button = LoginNextButton()
+        button.setTitle("다음화면으로 이동", for: .normal)
+        button.addTarget(self, action: #selector(goNextPage), for: .touchUpInside)
+        return button
+    }()
+    
+    private lazy var backButton: LoginBackButton = {
+        let button = LoginBackButton()
+        button.setTitle("취소하기", for: .normal)
+        button.addTarget(self, action: #selector(goBackPage), for: .touchUpInside)
+        return button
+    }()
+
+    private var countdownTimer: Timer?
+    private var countdownSeconds = 10
+    private var isVerificationButtonEnable = true
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        navigationController?.setNavigationBarHidden(true, animated: true) // 뷰 컨트롤러가 나타날 때 숨기기
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        navigationController?.setNavigationBarHidden(false, animated: true) // 뷰 컨트롤러가 사라질 때 나타내기
+    }
+
+    private func setupUI() {
+        view.backgroundColor = .white
+        
+        // 이메일 인증 및 인증 재요청
+        view.addSubview(emailTitle)
+        view.addSubview(emailTextField)
+        view.addSubview(verificationButton)
+        view.addSubview(countdownLabel)
+        emailTitle.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(16)
+            make.leading.equalTo(view.safeAreaLayoutGuide).offset(16)
+            make.trailing.equalTo(view.safeAreaLayoutGuide).offset(-16)
+        }
+
+        emailTextField.snp.makeConstraints { make in
+            make.top.equalTo(emailTitle.snp.bottom).offset(16)
+            make.leading.equalTo(view.safeAreaLayoutGuide).offset(16)
+            make.trailing.equalTo(view.safeAreaLayoutGuide).offset(-16)
+            make.height.equalTo(40)
+        }
+
+        verificationButton.snp.makeConstraints { make in
+            make.top.equalTo(emailTextField.snp.bottom).offset(12)
+            make.leading.equalTo(view.safeAreaLayoutGuide).offset(16)
+            make.trailing.equalTo(view.safeAreaLayoutGuide).offset(-16)
+            make.height.equalTo(40)
+        }
+
+        countdownLabel.snp.makeConstraints { make in
+            make.centerY.equalTo(emailTextField)
+            make.trailing.equalTo(view.safeAreaLayoutGuide).offset(-28)
+        }
+        
+        // 인증 확인
+        view.addSubview(authInputTextField)
+        view.addSubview(authConfirmButton)
+        authInputTextField.snp.makeConstraints { make in
+            make.top.equalTo(verificationButton.snp.bottom).offset(24)
+            make.leading.equalTo(view.safeAreaLayoutGuide).offset(16)
+            make.trailing.equalTo(view.safeAreaLayoutGuide).offset(-16)
+            make.height.equalTo(40)
+        }
+    
+        authConfirmButton.snp.makeConstraints { make in
+            make.top.equalTo(authInputTextField.snp.bottom).offset(16)
+            make.leading.equalTo(view.safeAreaLayoutGuide).offset(16)
+            make.trailing.equalTo(view.safeAreaLayoutGuide).offset(-16)
+            make.height.equalTo(40)
+        }
+        
+        // 화면 전환 버튼
+        view.addSubview(nextButton)
+        view.addSubview(backButton)
+        nextButton.snp.makeConstraints { make in
+            make.centerY.equalToSuperview().multipliedBy(1.5)
+            make.leading.trailing.equalToSuperview().inset(16)
+            make.height.equalTo(40)
+        }
+ 
+        backButton.snp.makeConstraints { make in
+            make.top.equalTo(nextButton.snp.bottom).offset(8)
+            make.leading.trailing.equalToSuperview().inset(16)
+            make.height.equalTo(40)
+        }
+        
+        // 이메일 인증요청 후에 등장
+        hideAuthField()
+    }
+    
+    private func hideAuthField() {
+        authInputTextField.isHidden = true
+        authConfirmButton.isHidden = true
+    }
+    
+    private func showAuthField() {
+        authInputTextField.isHidden = false
+        authConfirmButton.isHidden = false
+    }
+
+    @objc private func emailTextFieldDidChange(_ textField: UITextField) {
+        if let text = textField.text, !text.isEmpty, isVerificationButtonEnable {
+            verificationButton.isEnabled = true
+            verificationButton.backgroundColor = .buttonColor
+        } else {
+            verificationButton.isEnabled = false
+            verificationButton.backgroundColor = .gray
+        }
+    }
+    
+    @objc private func authTextFieldDidChange(_ textField: UITextField) {
+        if let text = textField.text, !text.isEmpty {
+            authConfirmButton.isEnabled = true
+            authConfirmButton.backgroundColor = .buttonColor
+        } else {
+            authConfirmButton.isEnabled = false
+            authConfirmButton.backgroundColor = .gray
+        }
+    }
+
+    @objc private func verificationButtonTapped() {
+        //TODO: 인증 코드 전송 로직 구현
+        startCountdown()
+        showAuthField()
+        verificationButton.setTitle("인증번호 재발송", for: .normal)
+        verificationButton.isEnabled = false
+        verificationButton.backgroundColor = .gray
+    }
+    
+    @objc private func authConfirmButtonTapped() {
+        let alert = UIAlertController(title: "인증이 완료되었습니다.", message: nil, preferredStyle: .alert)
+        
+        let loginAction = UIAlertAction(title: "확인", style: .default) { _ in
+            //TODO: 인증 코드 확인 로직 구현
+            print("인증 코드 확인 로직 구현")
+            self.emailTextField.isUserInteractionEnabled = false
+            self.emailTextField.backgroundColor = .systemGray6
+            self.emailTextField.textColor = .systemGray
+            
+            self.countdownTimer?.invalidate()
+            self.countdownLabel.isHidden = true
+            self.nextButton.isEnable = true
+            self.verificationButton.setTitle("인증 완료", for: .normal)
+            self.verificationButton.isEnabled = false
+            self.verificationButton.backgroundColor = .gray
+            
+        }
+        
+        alert.addAction(loginAction)
+        present(alert, animated: true, completion: nil)
+    }
+
+    private func startCountdown() {
+        countdownSeconds = 5
+        isVerificationButtonEnable.toggle()
+        countdownTimer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(updateCountdown), userInfo: nil, repeats: true)
+    }
+
+    @objc private func updateCountdown() {
+        guard countdownSeconds >= 0 else {
+            countdownTimer?.invalidate()
+            verificationButton.isEnabled = true
+            verificationButton.backgroundColor = .buttonColor
+            isVerificationButtonEnable.toggle()
+            return
+        }
+
+        let minutes = countdownSeconds / 60
+        let seconds = countdownSeconds % 60
+        countdownLabel.text = String(format: "%02d:%02d", minutes, seconds)
+
+        countdownSeconds -= 1
+    }
+    
+    @objc private func goNextPage() {
+        let passwordInputViewController = ResetPasswordInputViewController()
+        navigationController?.pushViewController(passwordInputViewController, animated:true)
+    }
+    
+    @objc private func goBackPage() {
+        navigationController?.popViewController(animated: true)
+    }
+}
+

--- a/Ourry/Ourry/Views/ResetPasswordInputViewController.swift
+++ b/Ourry/Ourry/Views/ResetPasswordInputViewController.swift
@@ -1,0 +1,188 @@
+//
+//  ResetPasswordInputViewController.swift
+//  Ourry
+//
+//  Created by SeongHoon Jang on 2023/12/10.
+//
+
+import UIKit
+import SnapKit
+
+class ResetPasswordInputViewController: UIViewController {
+    
+    private let passwordTitle: UILabel = {
+        let label = UILabel()
+        label.text = "새 비밀번호"
+        label.textColor = .black
+        label.font = .preferredFont(forTextStyle: .headline)
+        return label
+    }()
+    
+    private let passwordCheckTitle: UILabel = {
+        let label = UILabel()
+        label.text = "새 비밀번호 확인"
+        label.textColor = .black
+        label.font = .preferredFont(forTextStyle: .headline)
+        return label
+    }()
+    
+    private lazy var passwordTextField: PlaneTextField = {
+        let textField = PlaneTextField(placeholder: "새 비밀번호를 입력해주세요.")
+        textField.addTarget(self, action: #selector(passwordTextFieldDidChange), for: .editingChanged)
+        return textField
+    }()
+    
+    private lazy var confirmPasswordTextField: PlaneTextField = {
+        let textField = PlaneTextField(placeholder: "새 비밀번호를 한번 더 입력해주세요.")
+        textField.addTarget(self, action: #selector(passwordConfirmTextFieldDidChange), for: .editingChanged)
+        return textField
+    }()
+    
+    private lazy var passwordErrorLabel: UILabel = {
+        let label = UILabel()
+        label.sizeToFit()
+        label.text = "비밀번호는 대소문자를 포함해서 12자리에서 16자리를 입력해야 합니다."
+        label.numberOfLines = 0
+        label.font = UIFont.preferredFont(forTextStyle: .footnote)
+        label.textColor = .clear
+        return label
+    }()
+    
+    private lazy var confirmPasswordErrorLabel: UILabel = {
+        let label = UILabel()
+        label.sizeToFit()
+        label.numberOfLines = 0
+        label.text = "입력한 비밀번호와 일치하지 않습니다. 다시 확인해주세요."
+        label.font = UIFont.preferredFont(forTextStyle: .footnote)
+        label.textColor = .clear
+        return label
+    }()
+    
+    private lazy var nextButton: LoginNextButton = {
+        let button = LoginNextButton()
+        button.setTitle("비밀번호 변경하기", for: .normal)
+        button.addTarget(self, action: #selector(goNextPage), for: .touchUpInside)
+        return button
+    }()
+    
+    private lazy var backButton: LoginBackButton = {
+        let button = LoginBackButton()
+        button.setTitle("뒤로가기", for: .normal)
+        button.addTarget(self, action: #selector(goBackPage), for: .touchUpInside)
+        return button
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        navigationController?.setNavigationBarHidden(true, animated: true)
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        navigationController?.setNavigationBarHidden(false, animated: true)
+    }
+
+    //MARK: - Functions
+    private func setupUI() {
+        view.backgroundColor = .white
+        
+        // 새 비밀번호
+        view.addSubview(passwordTitle)
+        view.addSubview(passwordTextField)
+        view.addSubview(passwordErrorLabel)
+        passwordTitle.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(16)
+            make.leading.trailing.equalToSuperview().inset(16)
+        }
+        
+        passwordTextField.snp.makeConstraints { make in
+            make.top.equalTo(passwordTitle.snp.bottom).offset(6)
+            make.leading.trailing.equalToSuperview().inset(16)
+        }
+        
+        passwordErrorLabel.snp.makeConstraints { make in
+            make.top.equalTo(passwordTextField.snp.bottom).offset(6)
+            make.leading.trailing.equalToSuperview().inset(16)
+        }
+        
+        // 새 비밀번호 확인
+        view.addSubview(passwordCheckTitle)
+        view.addSubview(confirmPasswordTextField)
+        view.addSubview(confirmPasswordErrorLabel)
+        passwordCheckTitle.snp.makeConstraints{ make in
+            make.top.equalTo(passwordTextField.snp.bottom).offset(48)
+            make.leading.trailing.equalToSuperview().inset(16)
+        }
+        
+        confirmPasswordTextField.snp.makeConstraints { make in
+            make.top.equalTo(passwordCheckTitle.snp.bottom).offset(6)
+            make.leading.trailing.equalToSuperview().inset(16)
+        }
+        
+        confirmPasswordErrorLabel.snp.makeConstraints { make in
+            make.top.equalTo(confirmPasswordTextField.snp.bottom).offset(6)
+            make.leading.trailing.equalToSuperview().inset(16)
+        }
+        
+        // 화면전환 버튼
+        view.addSubview(nextButton)
+        view.addSubview(backButton)
+        nextButton.snp.makeConstraints { make in
+            make.centerY.equalToSuperview().multipliedBy(1.5)
+            make.leading.trailing.equalToSuperview().inset(16)
+            make.height.equalTo(40)
+        }
+        
+        backButton.snp.makeConstraints { make in
+            make.top.equalTo(nextButton.snp.bottom).offset(8)
+            make.leading.trailing.equalToSuperview().inset(16)
+            make.height.equalTo(40)
+        }
+        
+    }
+    
+    // 유효한 비밀번호인지 검사
+    func isValidPassword(pw: String?) -> Bool {
+        let password = pw ?? ""
+        return (password.count >= 8) && (password.count <= 16)
+    }
+    
+    @objc private func passwordTextFieldDidChange() {
+        if isValidPassword(pw: passwordTextField.text) {
+            passwordErrorLabel.textColor = .clear
+            nextButton.isEnable = isSamePassword(pw1: passwordTextField.text,
+                                                 pw2: confirmPasswordTextField.text) ? true : false
+        } else {
+            passwordErrorLabel.textColor = .red
+            nextButton.isEnable = false
+        }
+    }
+    
+    // 동일한 비밀번호를 입력했는지 검사
+    func isSamePassword(pw1: String?, pw2: String?) -> Bool {
+        return (pw1 ?? "") == (pw2 ?? "")
+    }
+    
+    @objc private func passwordConfirmTextFieldDidChange() {
+        if isSamePassword(pw1: passwordTextField.text,
+                           pw2: confirmPasswordTextField.text) {
+            confirmPasswordErrorLabel.textColor = .clear
+            nextButton.isEnable = isValidPassword(pw: passwordTextField.text) ? true : false
+        } else {
+            confirmPasswordErrorLabel.textColor = .red
+            nextButton.isEnable = false
+        }
+    }
+    
+    @objc private func goNextPage() {
+        //TODO: 비밀번호 변경 요청
+        navigationController?.popToRootViewController(animated: true)
+    }
+    
+    @objc private func goBackPage() {
+        navigationController?.popViewController(animated: true)
+    }
+}


### PR DESCRIPTION
# 배경
비밀번호 재설정에 필요한 로직을 추가했습니다.

# 작업내용
- 2ad7152f089c1b179e9758377bfb1dc0f74b34bc
  - 불필요한 주석을 제거했으며 코드의 위치를 재구성하고 주석을 추가했습니다.

- f41bfa508baa09cb4e030033453e6a46006958b2
  - 비밀번호 재설정 화면을 구현했습니다.
    - 타이머 기능이 적용된 이메일 인증 기능을 구현했습니다.
    - 인증이 완료되면 버튼이 활성화되도록 했습니다.
  - 비밀번호 재설정 화면을 구현했습니다.
    - 비밀번호가 적합한 경우에만 "변경 완료" 버튼이 활성화 되도록 했습니다.
  - 커스텀 컴포넌트를 추가했습니다.
    - 로그인 과정에서 반복적으로 사용되는 버튼(앞으로가기, 뒤로가기)을 커스텀 컴포넌트로 만들었습니다.

- 27aeec10fca1b55cfb9d81a93d515e3f2156ff26
  - 텍스트필드의 첫글자가 대문자로 강제되는 문제를 수정했습니다.

# 해야 할 일
- API 개발이 완료가 된 기능에 대해 통신이 가능하도록 합니다.
- 논의가 부족했던 부분에 대해 확정을 내고 코드에 추가 반영합니다.
- 중복적으로 사용되는 컴포넌트에 대해 어떻게 관리해야할지에 대한 고민을 하고있습니다.

# 스크린샷
### 비밀번호 재설정

<img src = "https://github.com/Ourry/Ourry-iOS/assets/57349859/a786427e-bafb-470b-946b-ab8ca299bf61" width="30%" height="30%">