### PR TITLE
질문 추가 화면 개발 및 키체인에 token을 추가할 수 있는 기능을 개발했습니다

### DIFF
--- a/Ourry/Ourry.xcodeproj/project.pbxproj
+++ b/Ourry/Ourry.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1102F9912B563DA0009FA539 /* KeychainHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1102F9902B563DA0009FA539 /* KeychainHelper.swift */; };
+		1102F9932B5D49DC009FA539 /* SelectCategoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1102F9922B5D49DC009FA539 /* SelectCategoryViewController.swift */; };
 		1107A3A32B29DF16009B1C51 /* SignUpEmailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1107A3A22B29DF16009B1C51 /* SignUpEmailViewController.swift */; };
 		1107A3A52B2B327A009B1C51 /* SignUpPasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1107A3A42B2B327A009B1C51 /* SignUpPasswordViewController.swift */; };
 		1107A3A72B2B32D4009B1C51 /* SignUpInformationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1107A3A62B2B32D4009B1C51 /* SignUpInformationViewController.swift */; };
@@ -54,6 +56,7 @@
 		11B0FCFA2B4FD07700971F9A /* CategoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B0FCF92B4FD07700971F9A /* CategoryCell.swift */; };
 		11B0FCFC2B4FD0D200971F9A /* Date+Extention.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B0FCFB2B4FD0D200971F9A /* Date+Extention.swift */; };
 		11B0FCFE2B4FDA4C00971F9A /* IconTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B0FCFD2B4FDA4C00971F9A /* IconTextView.swift */; };
+		11B0FD002B527CC900971F9A /* AddQuestionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B0FCFF2B527CC900971F9A /* AddQuestionViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -67,6 +70,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1102F9902B563DA0009FA539 /* KeychainHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelper.swift; sourceTree = "<group>"; };
+		1102F9922B5D49DC009FA539 /* SelectCategoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectCategoryViewController.swift; sourceTree = "<group>"; };
 		1107A3A22B29DF16009B1C51 /* SignUpEmailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpEmailViewController.swift; sourceTree = "<group>"; };
 		1107A3A42B2B327A009B1C51 /* SignUpPasswordViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpPasswordViewController.swift; sourceTree = "<group>"; };
 		1107A3A62B2B32D4009B1C51 /* SignUpInformationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpInformationViewController.swift; sourceTree = "<group>"; };
@@ -115,6 +120,7 @@
 		11B0FCF92B4FD07700971F9A /* CategoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryCell.swift; sourceTree = "<group>"; };
 		11B0FCFB2B4FD0D200971F9A /* Date+Extention.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extention.swift"; sourceTree = "<group>"; };
 		11B0FCFD2B4FDA4C00971F9A /* IconTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconTextView.swift; sourceTree = "<group>"; };
+		11B0FCFF2B527CC900971F9A /* AddQuestionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddQuestionViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -246,6 +252,7 @@
 				1107A3A82B2D894C009B1C51 /* LoginManager.swift */,
 				1107A3E72B3AAA98009B1C51 /* CreateAccountManager.swift */,
 				1107A3E92B3AAF7C009B1C51 /* PasswordResetManager.swift */,
+				1102F9902B563DA0009FA539 /* KeychainHelper.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -311,6 +318,8 @@
 			children = (
 				11B0FCEE2B4BD35F00971F9A /* MainCell */,
 				11B0FCE62B483B8600971F9A /* MainViewController.swift */,
+				11B0FCFF2B527CC900971F9A /* AddQuestionViewController.swift */,
+				1102F9922B5D49DC009FA539 /* SelectCategoryViewController.swift */,
 				11B0FCE82B492F5600971F9A /* MainTitleView.swift */,
 				11B0FCFD2B4FDA4C00971F9A /* IconTextView.swift */,
 			);
@@ -457,6 +466,8 @@
 			files = (
 				11B0FCE92B492F5600971F9A /* MainTitleView.swift in Sources */,
 				115E266A2B161BFE00FCBEE8 /* Color+Extention.swift in Sources */,
+				1102F9932B5D49DC009FA539 /* SelectCategoryViewController.swift in Sources */,
+				11B0FD002B527CC900971F9A /* AddQuestionViewController.swift in Sources */,
 				11793E742B22F160008FC22C /* LoginNextButton.swift in Sources */,
 				1107A3F92B42C9D4009B1C51 /* MockURLProtocol.swift in Sources */,
 				11793E782B24B47B008FC22C /* LoginBackButton.swift in Sources */,
@@ -472,6 +483,7 @@
 				11B0FCF82B4FD04D00971F9A /* QuestionTableCell.swift in Sources */,
 				1107A3A72B2B32D4009B1C51 /* SignUpInformationViewController.swift in Sources */,
 				1107A3AB2B2D8985009B1C51 /* Login.swift in Sources */,
+				1102F9912B563DA0009FA539 /* KeychainHelper.swift in Sources */,
 				1107A3EA2B3AAF7C009B1C51 /* PasswordResetManager.swift in Sources */,
 				11B0FCE72B483B8600971F9A /* MainViewController.swift in Sources */,
 				11793E612B188610008FC22C /* PlaneTextField.swift in Sources */,

--- a/Ourry/Ourry.xcodeproj/xcshareddata/xcschemes/Ourry.xcscheme
+++ b/Ourry/Ourry.xcodeproj/xcshareddata/xcschemes/Ourry.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1510"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "115E264D2B1618BE00FCBEE8"
+               BuildableName = "Ourry.app"
+               BlueprintName = "Ourry"
+               ReferencedContainer = "container:Ourry.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "115E264D2B1618BE00FCBEE8"
+            BuildableName = "Ourry.app"
+            BlueprintName = "Ourry"
+            ReferencedContainer = "container:Ourry.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "115E264D2B1618BE00FCBEE8"
+            BuildableName = "Ourry.app"
+            BlueprintName = "Ourry"
+            ReferencedContainer = "container:Ourry.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Ourry/Ourry/Managers/KeychainHelper.swift
+++ b/Ourry/Ourry/Managers/KeychainHelper.swift
@@ -1,0 +1,109 @@
+//
+//  KeychainHelper.swift
+//  Ourry
+//
+//  Created by SeongHoon Jang on 1/16/24.
+//
+
+import Foundation
+import Security
+
+//MARK: - KeychainHelper for CRUD of Token
+class KeychainHelper {
+    static let serviceName = "Ourry"
+    
+    @discardableResult
+    static func create(token: String, forAccount account: String) -> Bool {
+        
+        let keychainItem = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: account,
+            kSecAttrService: serviceName,
+            kSecValueData: token.data(using: .utf8) as Any
+        ] as [String: Any]
+        
+        // Add the password to the keychain.
+        let status = SecItemAdd(keychainItem as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            print("Keychain create Error")
+            return false
+        }
+        return true
+    }
+    
+    static func read(forAccount account: String) -> String? {
+        let keychainItem = [
+                    kSecClass: kSecClassGenericPassword,
+                    kSecAttrAccount: account,
+                    kSecAttrService: serviceName,
+                    kSecReturnData: true
+                ] as [String: Any]
+        
+        var item: AnyObject?
+        let status = SecItemCopyMatching(keychainItem as CFDictionary, &item)
+        if status == errSecSuccess {
+            return String(data: item as! Data, encoding: .utf8)
+        }
+        
+        if status == errSecItemNotFound {
+            print("The token was not found in keychain")
+            return nil
+        } else {
+            print("Error getting token from keychain: \(status)")
+            return nil
+        }
+    }
+    
+    @discardableResult
+    static func update(token: String, forAccount account: String) -> Bool{
+        let keychainItem = [
+            kSecClass: kSecClassGenericPassword
+        ] as [String: Any]
+
+        let attributes = [
+            kSecAttrService: serviceName,
+            kSecAttrAccount: account,
+            kSecValueData: token.data(using: .utf8) as Any
+        ]
+
+        let status = SecItemUpdate(keychainItem as CFDictionary, attributes as CFDictionary)
+        guard status != errSecItemNotFound else {
+            print("The token was not found in keychain")
+            return false
+        }
+
+        guard status == errSecSuccess else {
+            print("Keychain update Error")
+            return false
+        }
+        
+        print("The token in keychain is updated")
+        return true
+    }
+    
+    @discardableResult
+    static func delete(forAccount account: String) -> Bool{
+        let keychainItem = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: serviceName,
+            kSecAttrAccount: account
+        ] as [String: Any]
+
+        let status = SecItemDelete(keychainItem as CFDictionary)
+        guard status != errSecItemNotFound else {
+            print("The token was not found in keychain")
+            return false
+        }
+        guard status == errSecSuccess else {
+            print("Keychain delete Error")
+            return false
+        }
+        print("The token in keychain is deleted")
+        return true
+    }
+}
+
+// https://uniqueimaginate.tistory.com/30
+// https://medium.com/@omar.saibaa/local-storage-in-ios-keychain-668240e2670d
+// https://developer.apple.com/documentation/security/ksecreturndata
+// https://developer.apple.com/documentation/security/errsecsuccess

--- a/Ourry/Ourry/Views/AddQuestionViewController.swift
+++ b/Ourry/Ourry/Views/AddQuestionViewController.swift
@@ -1,0 +1,443 @@
+//
+//  AddQuestionViewController.swift
+//  Ourry
+//
+//  Created by SeongHoon Jang on 1/13/24.
+//
+
+import UIKit
+import SnapKit
+
+class AddQuestionViewController: UIViewController {
+    //MARK: - Properties
+    
+    let scrollView = UIScrollView()
+    let contentView = UIView()
+    
+    // Bar Button Item
+    private lazy var cancelButton: UIBarButtonItem = {
+        let button = UIBarButtonItem(title: "취소", style: .plain, target: self, action: #selector(cancelButtonTapped))
+        button.tintColor = .black
+        button.isEnabled = true
+        return button
+    }()
+    
+    private lazy var finishButton: UIBarButtonItem = {
+        let button = UIBarButtonItem(title: "완료", style: .plain, target: self, action: #selector(finishButtonTapped))
+        button.tintColor = .black
+        button.isEnabled = false
+        return button
+    }()
+    // 카테고리 선택
+    private lazy var categoryButton2: UIButton = {
+        var configuration = UIButton.Configuration.plain()
+        configuration.title = "카테고리를 선택해주세요."
+        configuration.image = UIImage(systemName: "chevron.right")
+
+        let button = UIButton(configuration: configuration, primaryAction: UIAction(handler: { _ in
+            print("Button tapped!")
+            let selectCategoryViewController = SelectCategoryViewController()
+            selectCategoryViewController.delegate = self
+            self.navigationController?.pushViewController(selectCategoryViewController, animated:true)
+            
+            
+        }))
+        
+        button.contentHorizontalAlignment = .left   // 왼쪽 정렬
+        button.semanticContentAttribute = .forceRightToLeft // 버튼과 타이틀의 순서 변경
+        button.imageView?.snp.makeConstraints {
+            $0.centerY.equalTo(button.snp.centerY)
+            $0.trailing.equalTo(button.snp.leading).offset(24)
+        }
+        
+        button.layer.cornerRadius = 8
+        button.backgroundColor = .white
+        button.tintColor = .black
+        
+        button.layer.masksToBounds = false
+        button.layer.shadowColor = UIColor.blueShadowColor.cgColor
+        button.layer.shadowOffset = CGSize(width: 1, height: 1)
+        button.layer.shadowOpacity = 1.0
+        button.layer.shadowRadius = 4.0
+        
+        return button
+    }()
+    
+//    var categoryButtonTitle: String = "카테고리를 선택하세요123"
+//    
+//    private lazy var categoryButton: UIButton = {
+//        let button = UIButton()
+//        button.tintColor = .black
+//        button.backgroundColor = .white
+//        button.setTitle(categoryButtonTitle, for: .normal)
+//        button.setTitleColor(.black, for: .normal)
+//        button.titleLabel?.font = .systemFont(ofSize: 16)
+//        button.setImage(UIImage(systemName: "chevron.right"), for: .normal)
+//        button.addTarget(self, action: #selector(categoryButtonTapped), for: .touchUpInside)
+//        
+//        button.layer.masksToBounds = false
+//        button.layer.shadowColor = UIColor.blueShadowColor.cgColor
+//        button.layer.shadowOffset = CGSize(width: 1, height: 1)
+//        button.layer.shadowOpacity = 1.0
+//        button.layer.shadowRadius = 4.0
+//        
+//        return button
+//    }()
+    
+    // 제목
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = ""
+        label.textColor = .darkGray
+        label.font = UIFont.boldSystemFont(ofSize: 17)
+        return label
+    }()
+    
+    private lazy var titleTextField: BlueShadowTextField = {
+        let textField = BlueShadowTextField(placeholder: "제목을 입력해주세요")
+        textField.autocorrectionType = .no
+        textField.spellCheckingType = .no
+        return textField
+    }()
+
+    // 설명
+    let placeholder = "설명을 작성해주세요."
+    let descriptionTextView: UITextView = {
+        let textView = UITextView()
+        textView.autocorrectionType = .no
+        textView.spellCheckingType = .no
+        textView.font = .systemFont(ofSize: 16)
+        textView.layer.cornerRadius = 18
+        textView.backgroundColor = .white
+        textView.tintColor = .blueShadowColor
+        textView.textContainerInset = UIEdgeInsets(top: 18, left: 18, bottom: 18, right: 18)
+        textView.isScrollEnabled = false
+        
+        textView.autocapitalizationType = .none
+        textView.layer.masksToBounds = false
+        textView.layer.shadowColor = UIColor.blueShadowColor.cgColor
+        textView.layer.shadowOffset = CGSize(width: 0, height: 1)
+        textView.layer.shadowOpacity = 1.0
+        textView.layer.shadowRadius = 4.0
+        return textView
+    }()
+    
+    let letterNumLabel: UILabel = {
+        let label = UILabel()
+        label.text = "0/150"
+        label.font = .systemFont(ofSize: 16)
+        label.textColor = .systemGray3
+        label.textAlignment = .right
+        return label
+    }()
+    
+    // 선택지
+    var chunks: [Chunk] = []  // 각 덩어리에 대한 정보를 저장하는 배열
+    private lazy var optionStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = 8
+        return stackView
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        configUI()
+        setupUI()
+        setupTextView()
+        addNewChunk()
+        addNewChunk()
+    }
+    
+    //MARK - UI
+    func configUI() {
+        self.title = "질문 등록하기"
+        self.navigationItem.leftBarButtonItem = cancelButton
+        self.navigationItem.rightBarButtonItem = finishButton
+        
+        scrollView.backgroundColor = .backgroundColor
+        view.addSubview(scrollView)
+        
+        scrollView.snp.makeConstraints {
+            $0.edges.equalTo(view)
+        }
+
+        scrollView.addSubview(contentView)
+//        contentView.backgroundColor = .green
+        contentView.snp.makeConstraints {
+            $0.edges.equalTo(scrollView)
+//            $0.leading.trailing.top.equalTo(scrollView)
+//            $0.leading.equalToSuperview() (scrollView.snp.leading)
+//            $0.trailing.equalToSuperview()(scrollView.snp.trailing)
+//            $0.top.equalToSuperview()
+            $0.width.height.equalTo(view)
+//            $0.height.equalTo(view)
+        }
+    }
+    
+    func setupUI() {
+        /// 카테고리 선택
+        contentView.addSubview(categoryButton2)
+        categoryButton2.snp.makeConstraints {
+            $0.top.equalTo(contentView).offset(16)
+            $0.height.equalTo(36)
+            $0.leading.trailing.equalTo(view).inset(16)
+        }
+        
+        /// 제목 입력
+        let titleView = UILabel()
+        titleView.text = "제목"
+        titleView.textColor = .darkGray
+        titleView.font = UIFont.boldSystemFont(ofSize: 17)
+
+        contentView.addSubview(titleView)
+
+        titleView.snp.makeConstraints {
+            $0.top.equalTo(categoryButton2.snp.bottom).offset(16)
+            $0.leading.trailing.equalTo(view).inset(16)
+        }
+        
+        contentView.addSubview(titleTextField)
+        titleTextField.snp.makeConstraints {
+            $0.top.equalTo(titleView.snp.bottom).offset(12)
+            $0.leading.trailing.equalTo(view).inset(16)
+        }
+        
+        /// 설명 입력
+        let descriptionView = UILabel()
+        descriptionView.text = "설명"
+        descriptionView.textColor = .darkGray
+        descriptionView.font = UIFont.boldSystemFont(ofSize: 17)
+        
+        contentView.addSubview(descriptionView)
+        descriptionView.snp.makeConstraints {
+            $0.top.equalTo(titleTextField.snp.bottom).offset(16)
+            $0.leading.trailing.equalTo(view).inset(16)
+        }
+        
+        contentView.addSubview(descriptionTextView)
+        contentView.addSubview(letterNumLabel)
+        
+        descriptionTextView.snp.makeConstraints { make in
+            make.top.equalTo(descriptionView.snp.bottom).offset(12)
+            make.leading.trailing.equalTo(view).inset(16)
+            make.height.greaterThanOrEqualTo(150)
+        }
+        
+        letterNumLabel.snp.makeConstraints { make in
+            make.top.equalTo(descriptionTextView.snp.bottom).offset(12)
+            make.trailing.equalToSuperview().inset(28)
+        }
+        
+        // 선택지 입력
+        let selectView = UILabel()
+        selectView.text = "선택지"
+        selectView.textColor = .darkGray
+        selectView.font = UIFont.boldSystemFont(ofSize: 17)
+
+        contentView.addSubview(selectView)
+        selectView.snp.makeConstraints {
+            $0.top.equalTo(letterNumLabel.snp.bottom).offset(16)
+            $0.leading.equalTo(16)
+        }
+        
+        //MARK: - 선택지
+        contentView.addSubview(optionStackView)
+        optionStackView.snp.makeConstraints {
+            $0.top.equalTo(selectView.snp.bottom).offset(12)
+            $0.leading.trailing.equalTo(contentView).inset(16)
+        }
+        
+        var configuration = UIButton.Configuration.plain()
+        configuration.title = "선택지 추가하기"
+
+        let tempButton = UIButton(configuration: configuration, primaryAction: UIAction(handler: { _ in
+            self.addNewChunk()
+            self.view.endEditing(true)
+        }))
+        tempButton.tintColor = .darkGray
+        tempButton.backgroundColor = .white
+
+        tempButton.layer.shadowColor = UIColor.blueShadowColor.cgColor
+        tempButton.layer.shadowOffset = CGSize(width: 0, height: 1)
+        tempButton.layer.shadowOpacity = 1.0
+        tempButton.layer.shadowRadius = 4.0
+        
+        
+        contentView.addSubview(tempButton)
+        tempButton.snp.makeConstraints {
+            $0.top.equalTo(optionStackView.snp.bottom).offset(8)
+            $0.leading.trailing.equalTo(contentView).inset(16)
+            $0.height.equalTo(36)
+        }
+        
+    }
+    
+    func setupTextView() {
+        descriptionTextView.delegate = self
+        descriptionTextView.text = placeholder /// 초반 placeholder 생성
+        descriptionTextView.textColor = .systemGray /// 초반 placeholder 색상 설정
+    }
+    
+    //MARK: - Action
+    @objc func cancelButtonTapped() {
+        self.dismiss(animated: true, completion: nil)
+    }
+    
+    @objc func finishButtonTapped() {
+        print("finish")
+        self.dismiss(animated: true, completion: nil)
+    }
+    
+    @objc func categoryButtonTapped() {
+        let signUpEmailViewController = SignUpEmailViewController()
+        navigationController?.pushViewController(signUpEmailViewController, animated:true)
+    }
+    
+    
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.view.endEditing(true) /// 화면을 누르면 키보드 내려가게 하는 것
+    }
+}
+
+
+//MARK: - UITextViewDelegate
+extension AddQuestionViewController: UITextViewDelegate {
+    
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        /// 텍스트뷰 입력 시 테두리 생기게 하기
+        descriptionTextView.layer.borderWidth = 2
+        descriptionTextView.layer.borderColor = UIColor.blueShadowColor.cgColor
+        
+        /// 플레이스홀더
+        if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            descriptionTextView.textColor = .systemGray
+            descriptionTextView.text = placeholder
+        } else if textView.text == placeholder {
+            descriptionTextView.textColor = .black
+            descriptionTextView.text = nil
+        }
+    }
+    
+    func textViewDidChange(_ textView: UITextView) {
+        // 글자 수 제한
+        if descriptionTextView.text.count > 300 {
+            descriptionTextView.deleteBackward()
+        }
+        
+        // 텍스트필드 크기 조절
+        let size = CGSize(width: view.frame.width, height: .infinity)
+        let estimatedSize = textView.sizeThatFits(size)
+        
+        textView.constraints.forEach { (constraint) in
+            if estimatedSize.height > 200 && constraint.firstAttribute == .height {
+                constraint.constant = estimatedSize.height
+            } else {
+                constraint.constant = 150
+            }
+        }
+
+        // 아래 글자 수 표시되게 하기
+        letterNumLabel.text = "\(descriptionTextView.text.count)/150"
+        
+        // 글자 수 부분 색상 변경
+        let attributedString = NSMutableAttributedString(string: "\(descriptionTextView.text.count)/150")
+        attributedString.addAttribute(.foregroundColor, value: UIColor.red, range: ("\(descriptionTextView.text.count)/150" as NSString).range(of:"\(descriptionTextView.text.count)"))
+        letterNumLabel.attributedText = attributedString
+    }
+    
+    func textViewDidEndEditing(_ textView: UITextView) {
+        // 텍스트뷰 입력 완료시 테두리 없애기
+        descriptionTextView.layer.borderWidth = 0
+        
+        /// 플레이스홀더
+        if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || textView.text == placeholder {
+            descriptionTextView.textColor = .systemGray
+            descriptionTextView.text = placeholder
+            letterNumLabel.textColor = .systemGray /// 텍스트 개수가 0일 경우에는 글자 수 표시 색상이 모두 gray 색이게 설정
+            letterNumLabel.text = "0/300"
+        }
+    }
+}
+
+//MARK: - 선택지 추가 및 삭제
+extension AddQuestionViewController: UITextFieldDelegate {
+    
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        let text = textField.text
+        textField.text = text
+    }
+    
+    // "X" 버튼을 눌렀을 때 호출되는 함수
+    @objc func removeChunk(sender: UIButton) {
+        if let chunkIndex = chunks.firstIndex(where: { $0.deleteButton == sender }) {
+            chunks.remove(at: chunkIndex)
+            sender.superview?.removeFromSuperview()
+        }
+    }
+
+    // 덩어리(텍스트필드+삭제버튼)를 추가하는 함수
+    func addNewChunk() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            
+            var chunk = Chunk()
+
+            let chunkView = UIView()
+
+            let textField = BlueShadowTextField(placeholder: "선택지를 입력해주세요.")
+            textField.autocorrectionType = .no
+            textField.spellCheckingType = .no
+            textField.delegate = self
+            
+            chunk.textField = textField  // 덩어리에 텍스트 필드 저장
+
+            let deleteButton = UIButton(type: .system)
+            deleteButton.setTitle("X", for: .normal)
+            deleteButton.tintColor = .darkGray
+            deleteButton.addTarget(self, action: #selector(removeChunk), for: .touchUpInside)
+            chunk.deleteButton = deleteButton  // 덩어리에 삭제 버튼 저장
+
+            chunkView.addSubview(textField)
+            chunkView.addSubview(deleteButton)
+
+            // Auto Layout 설정
+            textField.snp.makeConstraints {
+                $0.leading.trailing.top.bottom.equalToSuperview()
+                $0.height.equalTo(36)
+            }
+
+            deleteButton.snp.makeConstraints {
+                $0.centerY.equalTo(textField)
+                $0.trailing.equalTo(textField.snp.trailing).offset(-10)
+                $0.width.equalTo(30)
+            }
+
+            // Stack View에 추가
+            self.optionStackView.addArrangedSubview(chunkView)
+            self.chunks.append(chunk)
+        }
+        
+        
+    }
+
+    struct Chunk {
+        var textField: UITextField?
+        var deleteButton: UIButton?
+    }
+    
+    override func prepareForInterfaceBuilder() {
+        super.prepareForInterfaceBuilder()
+//        self.optionStackView =
+    }
+}
+
+//MARK: - SelectCategoryVCDelegate
+extension AddQuestionViewController: SelectCategoryVCDelegate {
+    func didSelectCategory(_ category: String) {
+        categoryButton2.setTitle(category, for: .normal)
+        navigationController?.popViewController(animated: true)
+    }
+}

--- a/Ourry/Ourry/Views/MainViewController.swift
+++ b/Ourry/Ourry/Views/MainViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 import SnapKit
 
 class MainViewController: UIViewController {
-
+    
     // MARK: - Properties
     // tltle view
     private let mainTitleView = MainTitleView()
@@ -34,7 +34,7 @@ class MainViewController: UIViewController {
     // main table view
     private var questions: [String] = ["가나다라마", "가나다라마바사아자차가나다라마바사아자차가나다라마바사아자차가나다라마바사아자차", "가나다라마바사아자차가나다라마바사아자차가나다라마바사아자차가나다라마바사아자차"]
     private lazy var mainTableView: UITableView = {
-       let tableView = UITableView()
+        let tableView = UITableView()
         tableView.separatorStyle = .none
         tableView.rowHeight = 112
         tableView.delegate = self
@@ -42,6 +42,14 @@ class MainViewController: UIViewController {
         tableView.register(QuestionTableCell.self, forCellReuseIdentifier: QuestionTableCell.reuseIdentifier)
         
         return tableView
+    }()
+    
+    // floating button
+    private lazy var addQuestionButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(named: "question_request_button.pdf"), for: .normal)
+        button.addTarget(self, action: #selector(addQuestionButtonTapped), for: .touchUpInside)
+        return button
     }()
     
     // MARK: - LifeCycle
@@ -52,16 +60,7 @@ class MainViewController: UIViewController {
         setupMainTitleView()
         setupMainTableView()
         setupCategoryUI()
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        self.navigationController?.isNavigationBarHidden = true
-    }
-    
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        self.navigationController?.isNavigationBarHidden = false
+        setupAddQuestionButton()
     }
     
     // MARK: - Helpers
@@ -106,12 +105,29 @@ class MainViewController: UIViewController {
         }
     }
     
+    func setupAddQuestionButton() {
+        view.addSubview(addQuestionButton)
+        
+        addQuestionButton.snp.makeConstraints {
+            $0.bottom.equalTo(view).offset(-42)
+            $0.trailing.equalTo(view).offset(-16)
+            $0.width.height.equalTo(52)
+        }
+    }
+    
     // MARK: - Actions
+    @objc func addQuestionButtonTapped() {
+        let addQuestionViewController = AddQuestionViewController()
+        let navigationController = UINavigationController(rootViewController: addQuestionViewController)
+        navigationController.modalPresentationStyle = .fullScreen
+        self.present(navigationController, animated: true, completion: nil)
+    }
+    
     func reloadDataForCurrentButton() {
         //TODO: - 현재 버튼에 맞게 서버에 데이터 요청 및 갱신
-//        dataToShow = [
-//            "Item \(currentButtonTag)"
-//        ]
+        //        dataToShow = [
+        //            "Item \(currentButtonTag)"
+        //        ]
         
         print("reload main table view")
         mainTableView.reloadData()
@@ -166,9 +182,9 @@ extension MainViewController: UITableViewDelegate, UITableViewDataSource {
             comment: 456,
             date: Date(timeIntervalSinceNow: -72000)
         )
-
+        
         return cell
-
+        
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/Ourry/Ourry/Views/SelectCategoryViewController.swift
+++ b/Ourry/Ourry/Views/SelectCategoryViewController.swift
@@ -1,0 +1,71 @@
+//
+//  SelectCategoryViewController.swift
+//  Ourry
+//
+//  Created by SeongHoon Jang on 1/21/24.
+//
+
+import UIKit
+import SnapKit
+
+protocol SelectCategoryVCDelegate: AnyObject {
+    func didSelectCategory(_ category: String)
+}
+
+class SelectCategoryViewController: UIViewController {
+    
+    weak var delegate: SelectCategoryVCDelegate?
+    
+    private let catogorys = ["가정/육아", "결혼/연애", "부동산/경제", "사회생활", "학업", "커리어"]
+    
+    private lazy var categoryStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = 8
+        return stackView
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        view.backgroundColor = .backgroundColor
+        setupUI()
+    }
+    
+    func setupUI() {
+        view.addSubview(categoryStackView)
+        categoryStackView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
+            $0.leading.trailing.equalTo(self.additionalSafeAreaInsets)
+        }
+
+        for category in catogorys {
+            let button = UIButton()
+            
+            button.tintColor = .blue
+            button.backgroundColor = .white
+            button.setTitle("\(category)", for: .normal)
+            button.setTitleColor(.black, for: .normal)
+            button.titleLabel?.font = .systemFont(ofSize: 16)
+
+            button.layer.shadowColor = UIColor.blueShadowColor.cgColor
+            button.layer.shadowOffset = CGSize(width: 1, height: 1)
+            button.layer.shadowOpacity = 1.0
+            button.layer.shadowRadius = 4.0
+            
+            button.addTarget(self, action: #selector(categoryButtonTapped), for: .touchUpInside)
+            
+            categoryStackView.addArrangedSubview(button)
+        }
+        
+    }
+    
+    @objc func categoryButtonTapped(_ sender: UIButton) {
+        if let category = sender.titleLabel?.text {
+            delegate?.didSelectCategory(category)
+        }
+    }
+
+ 
+    
+}


### PR DESCRIPTION
# 배경
질문을 추가할 수 있는 화면의 U를 개발했습니다.

# 작업내용
- 020c4933b3f5b6e4f802c9663078ecf021d04f70
  - 질문 추가를 할 수 있는 화면을 개발했습니다.
  - 카테고리 선택할 수 있는 기능을 개발했습니다.
  - 텍스트필드 형태의 선택지를 추가하고 삭제할 수 있는 기능을 개발했습니다.

- 23134aad460b516cdbaa4776dacb3fe2b847fedc
  - 토큰을 keychain에 CRUD 할 수 있는 기능을 개발했습니다.
  - jwt 토큰으로 부터 받아오게될 refresh token과 access token을 관리하는데 사용될 예정입니다.
  
# 이슈
- textfield관련 이슈
  - [UIKeyboardTaskQueue lockWhenReadyForMainThread] timeout waiting for task on queue
    위 버그가 발생해 골머리를 앓았습니다. 텍스트필드를 눌렀을 때 화면이 멈춰버리게되는 버그로 개발에 어려움을 겪었습니다. 정확한 원인을 파악할 수는 없으나 "수정 제안"이 등장하는 것으로 인해 발생하는 것 같았고, 해당 기능을 비활성화하여 해결할 수 있었습니다.
   [[티스토리]](https://jangsh9611.tistory.com/50) 에서 자세한 내용을 확인하실 수 있습니다.

# 해야 할 일
- token을 활용한 로그인 기능 개발

# 스크린샷

### 질문 추가 화면
<img src = "https://github.com/Ourry/Ourry-iOS/assets/57349859/56cd98ab-dc43-491a-b331-c366b75bc87f" width="30%" height="30%">

